### PR TITLE
Change ID columns to use v7 UUIDs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ select name, balance, version from pgledger_get_account($account_2_id);
 See ledger entries:
 
 ```sql
-select * from pgledger_entries where account_id = $account_2_id;
+select created_at, account_version, amount, account_previous_balance, account_current_balance from pgledger_entries where account_id = $account_2_id order by id;
 
-  id   | account_id | transfer_id | amount | account_previous_balance | account_current_balance | account_version |          created_at
--------+------------+-------------+--------+--------------------------+-------------------------+-----------------+-------------------------------
- 96198 |         42 |       48103 |  12.34 |                     0.00 |                   12.34 |               1 | 2025-03-19 21:31:03.596426+00
- 96200 |         42 |       48104 |  56.78 |                    12.34 |                   69.12 |               2 | 2025-03-19 21:31:21.615916+00
+          created_at           | account_version | amount | account_previous_balance | account_current_balance
+-------------------------------+-----------------+--------+--------------------------+-------------------------
+ 2025-04-28 04:24:50.787722+00 |               1 |  12.34 |                     0.00 |                   12.34
+ 2025-04-28 04:24:53.25815+00  |               2 |  56.78 |                    12.34 |                   69.12
 (2 rows)
 ```
 
@@ -73,7 +73,9 @@ select * from pgledger_create_transfers(($user1_usd, $liquidity_usd, '10.00'), (
 - Add effective date to transfers (for when the transfer is recorded now, but it's related to something from the past)
 - Make create_transfers function return account balances as well
 - Add metadata to accounts and transfers - json column?
-- Better primary keys - UUIDs? ULIDs? with prefixes or not? ideally monotonic
+- Better primary keys
+  - Currently using UUIDv7, but would love a prefixed ULID or similar. Prefixes like `pgla`, `pglt`, `pgle`, etc.
+  - If we use a type with an embedded time, do we need a `created_at` column? Or maybe we could add a view that includes it by parsing out the UUIDv7/ULID?
 - Query via versioned views
   - `select * from pgledger_transfers_v1`
   - This way I can iterate on the underlying tables without breaking queries

--- a/go/test/db_test.go
+++ b/go/test/db_test.go
@@ -225,10 +225,10 @@ func TestTransferWithInvalidAccountID(t *testing.T) {
 
 	account1 := createAccount(ctx, t, conn, "account 1", "USD")
 
-	_, err := createTransferReturnErr(ctx, conn, account1.ID, "999", "12.34")
+	_, err := createTransferReturnErr(ctx, conn, account1.ID, "C8C3BAB4-03C4-41CD-A3DE-999999999999", "12.34")
 	assert.ErrorContains(t, err, "violates foreign key constraint")
 
-	_, err = createTransferReturnErr(ctx, conn, "999", account1.ID, "12.34")
+	_, err = createTransferReturnErr(ctx, conn, "C8C3BAB4-03C4-41CD-A3DE-999999999999", account1.ID, "12.34")
 	assert.ErrorContains(t, err, "violates foreign key constraint")
 }
 

--- a/pgledger.sql
+++ b/pgledger.sql
@@ -1,5 +1,20 @@
+-- Function to generate uuidv7 at microsecond precision. It's not monotonic,
+-- but hopefully close enough at microsecond precision.
+--   From: https://postgresql.verite.pro/blog/2024/07/15/uuid-v7-pure-sql.html
+-- This can be replaced by the builtin uuidv7() function when it's released in
+-- PostgreSQL 18. That one will will be monotonic.
+CREATE FUNCTION pgledger_generate_id() RETURNS uuid
+AS $$
+ select encode(
+   substring(int8send(floor(t_ms)::int8) from 3) ||
+   int2send((7<<12)::int2 | ((t_ms-floor(t_ms))*4096)::int2) ||
+   substring(uuid_send(gen_random_uuid()) from 9 for 8)
+  , 'hex')::uuid
+  from (select extract(epoch from clock_timestamp())*1000 as t_ms) s
+$$ LANGUAGE sql volatile;
+
 CREATE TABLE pgledger_accounts (
-    id BIGSERIAL PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT pgledger_generate_id(),
     name TEXT NOT NULL,
     currency TEXT NOT NULL,
     balance NUMERIC NOT NULL DEFAULT 0,
@@ -11,9 +26,9 @@ CREATE TABLE pgledger_accounts (
 );
 
 CREATE TABLE pgledger_transfers (
-    id BIGSERIAL PRIMARY KEY,
-    from_account_id BIGINT NOT NULL REFERENCES pgledger_accounts(id),
-    to_account_id BIGINT NOT NULL REFERENCES pgledger_accounts(id),
+    id UUID PRIMARY KEY DEFAULT pgledger_generate_id(),
+    from_account_id UUID NOT NULL REFERENCES pgledger_accounts(id),
+    to_account_id UUID NOT NULL REFERENCES pgledger_accounts(id),
     amount NUMERIC NOT NULL,
     created_at TIMESTAMPTZ NOT NULL,
     CHECK (amount > 0 AND from_account_id != to_account_id)
@@ -23,9 +38,9 @@ CREATE INDEX ON pgledger_transfers(from_account_id);
 CREATE INDEX ON pgledger_transfers(to_account_id);
 
 CREATE TABLE pgledger_entries (
-    id BIGSERIAL PRIMARY KEY,
-    account_id BIGINT NOT NULL REFERENCES pgledger_accounts(id),
-    transfer_id BIGINT NOT NULL REFERENCES pgledger_transfers(id),
+    id UUID PRIMARY KEY DEFAULT pgledger_generate_id(),
+    account_id UUID NOT NULL REFERENCES pgledger_accounts(id),
+    transfer_id UUID NOT NULL REFERENCES pgledger_transfers(id),
     amount NUMERIC NOT NULL,
     account_previous_balance NUMERIC NOT NULL,
     account_current_balance NUMERIC NOT NULL,
@@ -36,7 +51,7 @@ CREATE TABLE pgledger_entries (
 CREATE INDEX ON pgledger_entries(account_id);
 CREATE INDEX ON pgledger_entries(transfer_id);
 
-CREATE OR REPLACE FUNCTION pgledger_add_account(name_param TEXT, currency_param TEXT) RETURNS TABLE(id BIGINT, name TEXT, currency TEXT, balance NUMERIC) AS $$
+CREATE OR REPLACE FUNCTION pgledger_add_account(name_param TEXT, currency_param TEXT) RETURNS TABLE(id UUID, name TEXT, currency TEXT, balance NUMERIC) AS $$
 BEGIN
     RETURN QUERY
     INSERT INTO pgledger_accounts (name, currency, allow_negative_balance, allow_positive_balance, created_at, updated_at)
@@ -51,7 +66,7 @@ CREATE OR REPLACE FUNCTION pgledger_create_account(
     allow_negative_balance_param BOOLEAN DEFAULT TRUE,
     allow_positive_balance_param BOOLEAN DEFAULT TRUE
 )
-RETURNS TABLE(id BIGINT, name TEXT, currency TEXT, balance NUMERIC, version BIGINT, allow_negative_balance BOOLEAN, allow_positive_balance BOOLEAN, created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ) AS $$
+RETURNS TABLE(id UUID, name TEXT, currency TEXT, balance NUMERIC, version BIGINT, allow_negative_balance BOOLEAN, allow_positive_balance BOOLEAN, created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ) AS $$
 BEGIN
     RETURN QUERY
     INSERT INTO pgledger_accounts (name, currency, allow_negative_balance, allow_positive_balance, created_at, updated_at)
@@ -62,8 +77,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pgledger_get_account(id_param BIGINT)
-RETURNS TABLE(id BIGINT, name TEXT, currency TEXT, balance NUMERIC, version BIGINT, allow_negative_balance BOOLEAN, allow_positive_balance BOOLEAN, created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ) AS $$
+CREATE OR REPLACE FUNCTION pgledger_get_account(id_param UUID)
+RETURNS TABLE(id UUID, name TEXT, currency TEXT, balance NUMERIC, version BIGINT, allow_negative_balance BOOLEAN, allow_positive_balance BOOLEAN, created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ) AS $$
 BEGIN
     RETURN QUERY
     SELECT pgledger_accounts.id, pgledger_accounts.name, pgledger_accounts.currency, pgledger_accounts.balance, pgledger_accounts.version,
@@ -74,7 +89,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pgledger_get_transfer(id_param BIGINT) RETURNS TABLE(id BIGINT, from_account_id BIGINT, to_account_id BIGINT, amount NUMERIC, created_at TIMESTAMPTZ) AS $$
+CREATE OR REPLACE FUNCTION pgledger_get_transfer(id_param UUID) RETURNS TABLE(id UUID, from_account_id UUID, to_account_id UUID, amount NUMERIC, created_at TIMESTAMPTZ) AS $$
 BEGIN
     RETURN QUERY
     SELECT
@@ -105,12 +120,12 @@ $$ LANGUAGE plpgsql;
 
 -- Define a composite type for transfer requests
 CREATE TYPE transfer_request AS (
-    from_account_id BIGINT,
-    to_account_id BIGINT,
+    from_account_id UUID,
+    to_account_id UUID,
     amount NUMERIC
 );
 
-CREATE OR REPLACE FUNCTION pgledger_create_transfer(from_account_id_param BIGINT, to_account_id_param BIGINT, amount_param NUMERIC) RETURNS TABLE(id BIGINT, from_account_id BIGINT, to_account_id BIGINT, amount NUMERIC, created_at TIMESTAMPTZ) AS $$
+CREATE OR REPLACE FUNCTION pgledger_create_transfer(from_account_id_param UUID, to_account_id_param UUID, amount_param NUMERIC) RETURNS TABLE(id UUID, from_account_id UUID, to_account_id UUID, amount NUMERIC, created_at TIMESTAMPTZ) AS $$
 BEGIN
     -- Simply call pgledger_create_transfers with a single transfer
     RETURN QUERY
@@ -123,17 +138,17 @@ $$ LANGUAGE plpgsql;
 -- Function to create multiple transfers in a single transaction
 CREATE OR REPLACE FUNCTION pgledger_create_transfers(
     VARIADIC transfers transfer_request[]
-) RETURNS TABLE(id BIGINT, from_account_id BIGINT, to_account_id BIGINT, amount NUMERIC, created_at TIMESTAMPTZ) AS $$
+) RETURNS TABLE(id UUID, from_account_id UUID, to_account_id UUID, amount NUMERIC, created_at TIMESTAMPTZ) AS $$
 DECLARE
     transfer transfer_request;
-    transfer_ids BIGINT[] := '{}';
-    transfer_id BIGINT;
+    transfer_ids UUID[] := '{}';
+    transfer_id UUID;
     from_account RECORD;
     to_account RECORD;
-    from_account_id_param BIGINT;
-    to_account_id_param BIGINT;
+    from_account_id_param UUID;
+    to_account_id_param UUID;
     amount_param NUMERIC;
-    all_account_ids BIGINT[] := '{}';
+    all_account_ids UUID[] := '{}';
 BEGIN
     -- Collect all unique account IDs and sort them to prevent deadlocks
     FOREACH transfer IN ARRAY transfers LOOP


### PR DESCRIPTION
The main advantage of UUIDs instead of incrementing integers is that the
IDs on different tables won't be the same, so you can't accidentally use
an ID from the wrong table by accident. v7 UUIDs are nicer than v4 since
they are ordered, but unfortunately, won't be included in PostgreSQL
until v18. For now, we have a custom implementation that can be removed
once there is native support.
