### PR TITLE
Add event_at to pgledger_transfers

### DIFF
--- a/go/test/test_helpers.go
+++ b/go/test/test_helpers.go
@@ -35,6 +35,7 @@ type Transfer struct {
 	ToAccountID   string
 	Amount        string
 	CreatedAt     time.Time
+	EventAt       time.Time
 }
 
 type Entry struct {
@@ -46,6 +47,7 @@ type Entry struct {
 	AccountCurrentBalance  string
 	AccountVersion         int
 	CreatedAt              time.Time
+	EventAt                time.Time
 }
 
 func dbconn(t TestingT) *pgxpool.Pool {


### PR DESCRIPTION
- Add `event_at` column and index on `pgledger_transfers`
- Make `event_at` parameter optional on `pgledger_create_transfer` and
  `pgledger_create_transfers`
- Set `event_at` to `now()` if not provided
- Add `event_at` to entries view by joining to transfers
- Add a section to the README explaining the feature
