### PR TITLE
Set up Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,17 @@
+name: Renovate
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0/15 * * * *"
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v43.0.7
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "**"
+      ],
+      "addLabels": [
+        "{{datasource}}"
+      ]
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
+  "prConcurrentLimit": 0,
+  "lockFileMaintenance": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
Dependabot seems to only upgrade some dependencies, so I'm hoping
renovate will catch the rest: https://docs.renovatebot.com/

This sets up Renovate to run as a GitHub Action on a cron schedule, but
also with the ability to be manually triggered.
