### PR TITLE
Only run renovate once a day

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I don't think we need to run it more frequently right now, and we can
always manually kick off the workflow if needed.
