### PR TITLE
Upgrade sqlfluff to fix variadic syntax bug

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -42,3 +42,9 @@ extended_capitalisation_policy = upper
 [sqlfluff:layout:type:colon]
 spacing_before = touch
 spacing_after = touch
+
+# This allows these unreserved keywords to be used as column names
+#   https://docs.sqlfluff.com/en/stable/reference/rules.html#rule-references.keywords
+#   https://www.postgresql.org/docs/current/sql-keywords-appendix.html
+[sqlfluff:rules:references.keywords]
+ignore_words = name, version

--- a/examples/basic-example.sql.out
+++ b/examples/basic-example.sql.out
@@ -23,21 +23,21 @@ SELECT * FROM pgledger_accounts_view
 WHERE id =:'user1_external_id';
                id                |      name      | currency | balance | version | allow_negative_balance | allow_positive_balance |          created_at           |          updated_at           
 ---------------------------------+----------------+----------+---------+---------+------------------------+------------------------+-------------------------------+-------------------------------
- pgla_01K398HBM8EAPBGD23PGR118JA | user1.external | USD      |       0 |       0 | t                      | t                      | 2025-08-22 16:07:09.702979+00 | 2025-08-22 16:07:09.702979+00
+ pgla_01K7WQDC21E7DA3X5EGARKM63X | user1.external | USD      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.215912+00 | 2025-10-18 22:35:29.215912+00
 (1 row)
 
 -- The first step in the flow is a $50 payment is created and we are waiting for funds to arrive:
 SELECT * FROM pgledger_create_transfer(:'user1_external_id',:'user1_receivables_id', 50.00);
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K398HBMCECNRPT2S9M0MCE42 | pgla_01K398HBM8EAPBGD23PGR118JA | pgla_01K398HBM9EYB8WNG5B2N031VS |  50.00 | 2025-08-22 16:07:09.706692+00 | 2025-08-22 16:07:09.706692+00
+ pglt_01K7WQDC24F6X99MCX3FABR6MK | pgla_01K7WQDC21E7DA3X5EGARKM63X | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 |  50.00 | 2025-10-18 22:35:29.219475+00 | 2025-10-18 22:35:29.219475+00
 (1 row)
 
 -- Next, the funds arrive in our account, so we remove them from receivables and make them available:
 SELECT * FROM pgledger_create_transfer(:'user1_receivables_id',:'user1_available_id', 50.00);
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K398HBMDFGTRV884F9P83FF4 | pgla_01K398HBM9EYB8WNG5B2N031VS | pgla_01K398HBM9FRTVBHCAXZ37RB85 |  50.00 | 2025-08-22 16:07:09.709565+00 | 2025-08-22 16:07:09.709565+00
+ pglt_01K7WQDC25FGRABZFCA8HTC148 | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pgla_01K7WQDC22FFPRD998G0ZYYW01 |  50.00 | 2025-10-18 22:35:29.221555+00 | 2025-10-18 22:35:29.221555+00
 (1 row)
 
 -- Now, we can query the accounts and see the balances. We aren't waiting on
@@ -55,8 +55,8 @@ WHERE account_id =:'user1_receivables_id'
 ORDER BY account_version;
                id                |           account_id            |           transfer_id           | amount | account_previous_balance | account_current_balance | account_version |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+--------------------------+-------------------------+-----------------+-------------------------------+-------------------------------
- pgle_01K398HBMDEFFVVH0981XGBTDA | pgla_01K398HBM9EYB8WNG5B2N031VS | pglt_01K398HBMCECNRPT2S9M0MCE42 |  50.00 |                     0.00 |                   50.00 |               1 | 2025-08-22 16:07:09.706692+00 | 2025-08-22 16:07:09.706692+00
- pgle_01K398HBMDFSDBJ43MKBX8FADZ | pgla_01K398HBM9EYB8WNG5B2N031VS | pglt_01K398HBMDFGTRV884F9P83FF4 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-08-22 16:07:09.709565+00 | 2025-08-22 16:07:09.709565+00
+ pgle_01K7WQDC25EENVCGSR3S20Z3TF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC24F6X99MCX3FABR6MK |  50.00 |                     0.00 |                   50.00 |               1 | 2025-10-18 22:35:29.219475+00 | 2025-10-18 22:35:29.219475+00
+ pgle_01K7WQDC25FPZTRBE6HQFHX0NF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC25FGRABZFCA8HTC148 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-10-18 22:35:29.221555+00 | 2025-10-18 22:35:29.221555+00
 (2 rows)
 
 -- Continuing the example, let's issue a partial refund of the payment. When we
@@ -65,7 +65,7 @@ ORDER BY account_version;
 SELECT * FROM pgledger_create_transfer(:'user1_available_id',:'user1_pending_outbound_id', 20.00);
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K398HBMEFHQRQ2CKPRET4M9V | pgla_01K398HBM9FRTVBHCAXZ37RB85 | pgla_01K398HBMAED49QW4QJ6HM4M0B |  20.00 | 2025-08-22 16:07:09.710622+00 | 2025-08-22 16:07:09.710622+00
+ pglt_01K7WQDC26FBX8NWQ39B1Q2FRH | pgla_01K7WQDC22FFPRD998G0ZYYW01 | pgla_01K7WQDC23E2NSZ5QFWCG0836C |  20.00 | 2025-10-18 22:35:29.222531+00 | 2025-10-18 22:35:29.222531+00
 (1 row)
 
 -- Once we get confirmation that that refund was sent, We can move the money
@@ -83,7 +83,7 @@ FROM
     );
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |          event_at          
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+----------------------------
- pglt_01K398HBMFETR9XDE61HQ2NH8Q | pgla_01K398HBMAED49QW4QJ6HM4M0B | pgla_01K398HBM8EAPBGD23PGR118JA |  20.00 | 2025-08-22 16:07:09.711208+00 | 2025-07-21 12:45:54.123+00
+ pglt_01K7WQDC27EAY9NX3FDY8AYFHP | pgla_01K7WQDC23E2NSZ5QFWCG0836C | pgla_01K7WQDC21E7DA3X5EGARKM63X |  20.00 | 2025-10-18 22:35:29.223033+00 | 2025-07-21 12:45:54.123+00
 (1 row)
 
 -- Now, we can query the current state. The external account has -$30 ($50
@@ -107,13 +107,13 @@ WHERE id IN (:'user1_external_id',:'user1_receivables_id',:'user1_available_id',
 SELECT * FROM pgledger_create_transfer(:'user1_external_id',:'user1_receivables_id', 10.00);
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K398HBMGE7FSH6000VVTHK80 | pgla_01K398HBM8EAPBGD23PGR118JA | pgla_01K398HBM9EYB8WNG5B2N031VS |  10.00 | 2025-08-22 16:07:09.711938+00 | 2025-08-22 16:07:09.711938+00
+ pglt_01K7WQDC27FF5RP0YXGC7J8MSC | pgla_01K7WQDC21E7DA3X5EGARKM63X | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 |  10.00 | 2025-10-18 22:35:29.223573+00 | 2025-10-18 22:35:29.223573+00
 (1 row)
 
 SELECT * FROM pgledger_create_transfer(:'user1_receivables_id',:'user1_available_id', 8.00);
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K398HBMGFNWTB8RPDCXDZQAW | pgla_01K398HBM9EYB8WNG5B2N031VS | pgla_01K398HBM9FRTVBHCAXZ37RB85 |   8.00 | 2025-08-22 16:07:09.712689+00 | 2025-08-22 16:07:09.712689+00
+ pglt_01K7WQDC28EADBK610K6C92P47 | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pgla_01K7WQDC22FFPRD998G0ZYYW01 |   8.00 | 2025-10-18 22:35:29.224044+00 | 2025-10-18 22:35:29.224044+00
 (1 row)
 
 -- Now, we can see that our receivables balance is not $0 like we expect:
@@ -130,9 +130,9 @@ WHERE account_id =:'user1_receivables_id'
 ORDER BY account_version;
                id                |           account_id            |           transfer_id           | amount | account_previous_balance | account_current_balance | account_version |          created_at           |           event_at            
 ---------------------------------+---------------------------------+---------------------------------+--------+--------------------------+-------------------------+-----------------+-------------------------------+-------------------------------
- pgle_01K398HBMDEFFVVH0981XGBTDA | pgla_01K398HBM9EYB8WNG5B2N031VS | pglt_01K398HBMCECNRPT2S9M0MCE42 |  50.00 |                     0.00 |                   50.00 |               1 | 2025-08-22 16:07:09.706692+00 | 2025-08-22 16:07:09.706692+00
- pgle_01K398HBMDFSDBJ43MKBX8FADZ | pgla_01K398HBM9EYB8WNG5B2N031VS | pglt_01K398HBMDFGTRV884F9P83FF4 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-08-22 16:07:09.709565+00 | 2025-08-22 16:07:09.709565+00
- pgle_01K398HBMGEKERD38DNF6C7RKA | pgla_01K398HBM9EYB8WNG5B2N031VS | pglt_01K398HBMGE7FSH6000VVTHK80 |  10.00 |                     0.00 |                   10.00 |               3 | 2025-08-22 16:07:09.711938+00 | 2025-08-22 16:07:09.711938+00
- pgle_01K398HBMGFYVBCTM6YBM8BXN1 | pgla_01K398HBM9EYB8WNG5B2N031VS | pglt_01K398HBMGFNWTB8RPDCXDZQAW |  -8.00 |                    10.00 |                    2.00 |               4 | 2025-08-22 16:07:09.712689+00 | 2025-08-22 16:07:09.712689+00
+ pgle_01K7WQDC25EENVCGSR3S20Z3TF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC24F6X99MCX3FABR6MK |  50.00 |                     0.00 |                   50.00 |               1 | 2025-10-18 22:35:29.219475+00 | 2025-10-18 22:35:29.219475+00
+ pgle_01K7WQDC25FPZTRBE6HQFHX0NF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC25FGRABZFCA8HTC148 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-10-18 22:35:29.221555+00 | 2025-10-18 22:35:29.221555+00
+ pgle_01K7WQDC27FQ3TSF3FAQMNFTJW | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC27FF5RP0YXGC7J8MSC |  10.00 |                     0.00 |                   10.00 |               3 | 2025-10-18 22:35:29.223573+00 | 2025-10-18 22:35:29.223573+00
+ pgle_01K7WQDC28EHEA1JS1XP47N40M | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC28EADBK610K6C92P47 |  -8.00 |                    10.00 |                    2.00 |               4 | 2025-10-18 22:35:29.224044+00 | 2025-10-18 22:35:29.224044+00
 (4 rows)
 

--- a/examples/multi-currency.sql
+++ b/examples/multi-currency.sql
@@ -53,7 +53,7 @@ SELECT * FROM pgledger_create_transfers(
 -- same accounts in reverse order.
 
 -- It is also possible to specify the event_at with `pgledger_create_transfers` using named arguments:
-SELECT * FROM pgledger_create_transfers( -- noqa
+SELECT * FROM pgledger_create_transfers(
     event_at => '2025-07-21T12:45:54.123Z',
     VARIADIC transfer_requests => ARRAY[
         (:'user2_usd_id',:'liquidity_usd_id', '10.00'),

--- a/examples/multi-currency.sql.out
+++ b/examples/multi-currency.sql.out
@@ -25,8 +25,8 @@ SELECT * FROM pgledger_accounts_view
 WHERE name LIKE 'user2.%';
                id                |   name    | currency | balance | version | allow_negative_balance | allow_positive_balance |          created_at           |          updated_at           
 ---------------------------------+-----------+----------+---------+---------+------------------------+------------------------+-------------------------------+-------------------------------
- pgla_01K398HBRHF4QR3Q0FA0CGQ63P | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-08-22 16:07:09.840536+00 | 2025-08-22 16:07:09.840536+00
- pgla_01K398HBRJF25VR8M0MT6BSFKB | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-08-22 16:07:09.842424+00 | 2025-08-22 16:07:09.842424+00
+ pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.358662+00 | 2025-10-18 22:35:29.358662+00
+ pgla_01K7WQDC6GFDCVGQZQZN7CA4AK | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.360634+00 | 2025-10-18 22:35:29.360634+00
 (2 rows)
 
 -- And you can even use PostgreSQL's ltree functionality for querying
@@ -37,12 +37,14 @@ SELECT * FROM pgledger_accounts_view
 WHERE name::LTREE <@ 'user2';
                id                |   name    | currency | balance | version | allow_negative_balance | allow_positive_balance |          created_at           |          updated_at           
 ---------------------------------+-----------+----------+---------+---------+------------------------+------------------------+-------------------------------+-------------------------------
- pgla_01K398HBRHF4QR3Q0FA0CGQ63P | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-08-22 16:07:09.840536+00 | 2025-08-22 16:07:09.840536+00
- pgla_01K398HBRJF25VR8M0MT6BSFKB | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-08-22 16:07:09.842424+00 | 2025-08-22 16:07:09.842424+00
+ pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.358662+00 | 2025-10-18 22:35:29.358662+00
+ pgla_01K7WQDC6GFDCVGQZQZN7CA4AK | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.360634+00 | 2025-10-18 22:35:29.360634+00
 (2 rows)
 
 -- Now, we can see that pgledger prevents transfers between accounts of different currencies:
 SELECT * FROM pgledger_create_transfer(:'user2_usd_id',:'user2_eur_id', 10.00);
+-- Instead, we need to create liquidity accounts per currency and use those for the transfers:
+SELECT id FROM pgledger_create_account('liquidity.usd', 'USD') \gset liquidity_usd_
 ERROR:  Cannot transfer between different currencies (USD and EUR)
 CONTEXT:  PL/pgSQL function pgledger_create_transfers(timestamp with time zone,transfer_request[]) line 64 at RAISE
 SQL statement "SELECT * FROM pgledger_create_transfers(
@@ -50,8 +52,6 @@ SQL statement "SELECT * FROM pgledger_create_transfers(
         ROW(from_account_id, to_account_id, amount)::transfer_request
     )"
 PL/pgSQL function pgledger_create_transfer(text,text,numeric,timestamp with time zone) line 4 at RETURN QUERY
--- Instead, we need to create liquidity accounts per currency and use those for the transfers:
-SELECT id FROM pgledger_create_account('liquidity.usd', 'USD') \gset liquidity_usd_
 SELECT id FROM pgledger_create_account('liquidity.eur', 'EUR') \gset liquidity_eur_
 -- Now, a currency conversion consist of 2 transfers using the 4 accounts. The
 -- difference between these two different amounts (10.00 vs 9.26) is the
@@ -60,10 +60,10 @@ SELECT * FROM pgledger_create_transfers(
     (:'user2_usd_id',:'liquidity_usd_id', '10.00'),
     (:'liquidity_eur_id',:'user2_eur_id', '9.26')
 );
-               id                |         from_account_id         |          to_account_id          | amount |          created_at          |           event_at           
----------------------------------+---------------------------------+---------------------------------+--------+------------------------------+------------------------------
- pglt_01K398HBRVF32SJYYA28D1SVZQ | pgla_01K398HBRHF4QR3Q0FA0CGQ63P | pgla_01K398HBRTEM1AKBGQST5CE59Y |  10.00 | 2025-08-22 16:07:09.85124+00 | 2025-08-22 16:07:09.85124+00
- pglt_01K398HBRWE54AKNHNMS86T4ZX | pgla_01K398HBRTFV4S933PK9QSVS0Y | pgla_01K398HBRJF25VR8M0MT6BSFKB |   9.26 | 2025-08-22 16:07:09.85124+00 | 2025-08-22 16:07:09.85124+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
+ pglt_01K7WQDC6VE9ARJ9ZGX4TAGXZQ | pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | pgla_01K7WQDC6TED9VZP8CQWZV00AJ |  10.00 | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00
+ pglt_01K7WQDC6VF2QRVCX16VSN4ZSC | pgla_01K7WQDC6TF7VSY5PWXJ95B28H | pgla_01K7WQDC6GFDCVGQZQZN7CA4AK |   9.26 | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00
 (2 rows)
 
 -- Note that this used the plural `pgledger_create_transfers` instead of the
@@ -72,7 +72,7 @@ SELECT * FROM pgledger_create_transfers(
 -- likely to result in deadlocks since bidrectional transfers will lock the
 -- same accounts in reverse order.
 -- It is also possible to specify the event_at with `pgledger_create_transfers` using named arguments:
-SELECT * FROM pgledger_create_transfers( -- noqa
+SELECT * FROM pgledger_create_transfers(
     event_at => '2025-07-21T12:45:54.123Z',
     VARIADIC transfer_requests => ARRAY[
         (:'user2_usd_id',:'liquidity_usd_id', '10.00'),
@@ -81,8 +81,8 @@ SELECT * FROM pgledger_create_transfers( -- noqa
 );
                id                |         from_account_id         |          to_account_id          | amount |          created_at           |          event_at          
 ---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+----------------------------
- pglt_01K398HBRWFAP8W741WD3VRM23 | pgla_01K398HBRHF4QR3Q0FA0CGQ63P | pgla_01K398HBRTEM1AKBGQST5CE59Y |  10.00 | 2025-08-22 16:07:09.852473+00 | 2025-07-21 12:45:54.123+00
- pglt_01K398HBRWFXCAJK1BYTWJPJ4X | pgla_01K398HBRTFV4S933PK9QSVS0Y | pgla_01K398HBRJF25VR8M0MT6BSFKB |   9.26 | 2025-08-22 16:07:09.852473+00 | 2025-07-21 12:45:54.123+00
+ pglt_01K7WQDC6WE1WTT4B8P2WQDXYG | pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | pgla_01K7WQDC6TED9VZP8CQWZV00AJ |  10.00 | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00
+ pglt_01K7WQDC6WEEMBCWSF0G00PJKA | pgla_01K7WQDC6TF7VSY5PWXJ95B28H | pgla_01K7WQDC6GFDCVGQZQZN7CA4AK |   9.26 | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00
 (2 rows)
 
 -- Here is what the transfers look like holistically:
@@ -97,11 +97,11 @@ FROM pgledger_transfers_view t
 LEFT JOIN pgledger_accounts_view acc_from ON t.from_account_id = acc_from.id
 LEFT JOIN pgledger_accounts_view acc_to ON t.to_account_id = acc_to.id
 WHERE acc_from.name LIKE 'user2.%' OR acc_from.name LIKE 'liquidity.%';
-               id                |          created_at           |           event_at           |   acc_from    |    acc_to     | amount 
----------------------------------+-------------------------------+------------------------------+---------------+---------------+--------
- pglt_01K398HBRVF32SJYYA28D1SVZQ | 2025-08-22 16:07:09.85124+00  | 2025-08-22 16:07:09.85124+00 | user2.usd     | liquidity.usd |  10.00
- pglt_01K398HBRWE54AKNHNMS86T4ZX | 2025-08-22 16:07:09.85124+00  | 2025-08-22 16:07:09.85124+00 | liquidity.eur | user2.eur     |   9.26
- pglt_01K398HBRWFAP8W741WD3VRM23 | 2025-08-22 16:07:09.852473+00 | 2025-07-21 12:45:54.123+00   | user2.usd     | liquidity.usd |  10.00
- pglt_01K398HBRWFXCAJK1BYTWJPJ4X | 2025-08-22 16:07:09.852473+00 | 2025-07-21 12:45:54.123+00   | liquidity.eur | user2.eur     |   9.26
+               id                |          created_at           |           event_at            |   acc_from    |    acc_to     | amount 
+---------------------------------+-------------------------------+-------------------------------+---------------+---------------+--------
+ pglt_01K7WQDC6VE9ARJ9ZGX4TAGXZQ | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00 | user2.usd     | liquidity.usd |  10.00
+ pglt_01K7WQDC6VF2QRVCX16VSN4ZSC | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00 | liquidity.eur | user2.eur     |   9.26
+ pglt_01K7WQDC6WE1WTT4B8P2WQDXYG | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00    | user2.usd     | liquidity.usd |  10.00
+ pglt_01K7WQDC6WEEMBCWSF0G00PJKA | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00    | liquidity.eur | user2.eur     |   9.26
 (4 rows)
 

--- a/justfile
+++ b/justfile
@@ -55,12 +55,12 @@ modernize:
   cd go && go run {{MODERNIZE_CMD}} -test ./...
 
 lint-sql:
-  uvx sqlfluff@latest lint --verbose
+  uvx sqlfluff@3.5.0 lint --verbose
 
 format-sql:
-  uvx sqlfluff@latest format
+  uvx sqlfluff@3.5.0 format
 
-check: dbreset clean tidy test lint
+check: dbreset clean tidy format-sql test lint
 
 run-examples: dbreset
   #!/usr/bin/env bash


### PR DESCRIPTION
sqlfluff bug: https://github.com/sqlfluff/sqlfluff/issues/7103

The upgrade now requires ignoring some unreserved keywords, such as
`name` and `version`.
