### PR TITLE
Add optional JSON metadata when creating transfers

### DIFF
--- a/examples/basic-example.sql
+++ b/examples/basic-example.sql
@@ -47,14 +47,16 @@ SELECT * FROM pgledger_create_transfer(:'user1_available_id',:'user1_pending_out
 -- back to the user's external account (e.g. their credit/debit card). Often,
 -- this confirmation will come as a webhook or bank file or similar, so we can
 -- record the event time in the confirmation separately from the time we record
--- the ledger transfer (event_at vs created_at):
+-- the ledger transfer (event_at vs created_at). We can also record extra metadata
+-- as JSON that helps us tie it all together:
 SELECT *
 FROM
     pgledger_create_transfer(
         :'user1_pending_outbound_id',
         :'user1_external_id',
         20.00,
-        event_at => '2025-07-21T12:45:54.123Z'
+        event_at => '2025-07-21T12:45:54.123Z',
+        metadata => '{"webhook_id": "webhook_123"}'
     );
 
 -- Now, we can query the current state. The external account has -$30 ($50

--- a/examples/basic-example.sql.out
+++ b/examples/basic-example.sql.out
@@ -23,21 +23,21 @@ SELECT * FROM pgledger_accounts_view
 WHERE id =:'user1_external_id';
                id                |      name      | currency | balance | version | allow_negative_balance | allow_positive_balance |          created_at           |          updated_at           
 ---------------------------------+----------------+----------+---------+---------+------------------------+------------------------+-------------------------------+-------------------------------
- pgla_01K7WQDC21E7DA3X5EGARKM63X | user1.external | USD      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.215912+00 | 2025-10-18 22:35:29.215912+00
+ pgla_01K8KW44WGFBNVZ0WC5WX0A9QT | user1.external | USD      |       0 |       0 | t                      | t                      | 2025-10-27 22:20:21.774992+00 | 2025-10-27 22:20:21.774992+00
 (1 row)
 
 -- The first step in the flow is a $50 payment is created and we are waiting for funds to arrive:
 SELECT * FROM pgledger_create_transfer(:'user1_external_id',:'user1_receivables_id', 50.00);
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K7WQDC24F6X99MCX3FABR6MK | pgla_01K7WQDC21E7DA3X5EGARKM63X | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 |  50.00 | 2025-10-18 22:35:29.219475+00 | 2025-10-18 22:35:29.219475+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------+----------
+ pglt_01K8KW44WMFGHBYQK301HH4J3F | pgla_01K8KW44WGFBNVZ0WC5WX0A9QT | pgla_01K8KW44WHFNZA243705PBPBVH |  50.00 | 2025-10-27 22:20:21.779585+00 | 2025-10-27 22:20:21.779585+00 | 
 (1 row)
 
 -- Next, the funds arrive in our account, so we remove them from receivables and make them available:
 SELECT * FROM pgledger_create_transfer(:'user1_receivables_id',:'user1_available_id', 50.00);
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K7WQDC25FGRABZFCA8HTC148 | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pgla_01K7WQDC22FFPRD998G0ZYYW01 |  50.00 | 2025-10-18 22:35:29.221555+00 | 2025-10-18 22:35:29.221555+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------+----------
+ pglt_01K8KW44WNFDAVFY5BEXV08VP1 | pgla_01K8KW44WHFNZA243705PBPBVH | pgla_01K8KW44WJFRSABYAZK38R44CQ |  50.00 | 2025-10-27 22:20:21.781562+00 | 2025-10-27 22:20:21.781562+00 | 
 (1 row)
 
 -- Now, we can query the accounts and see the balances. We aren't waiting on
@@ -53,37 +53,39 @@ WHERE id =:'user1_receivables_id';
 SELECT * FROM pgledger_entries_view
 WHERE account_id =:'user1_receivables_id'
 ORDER BY account_version;
-               id                |           account_id            |           transfer_id           | amount | account_previous_balance | account_current_balance | account_version |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+--------------------------+-------------------------+-----------------+-------------------------------+-------------------------------
- pgle_01K7WQDC25EENVCGSR3S20Z3TF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC24F6X99MCX3FABR6MK |  50.00 |                     0.00 |                   50.00 |               1 | 2025-10-18 22:35:29.219475+00 | 2025-10-18 22:35:29.219475+00
- pgle_01K7WQDC25FPZTRBE6HQFHX0NF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC25FGRABZFCA8HTC148 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-10-18 22:35:29.221555+00 | 2025-10-18 22:35:29.221555+00
+               id                |           account_id            |           transfer_id           | amount | account_previous_balance | account_current_balance | account_version |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+--------------------------+-------------------------+-----------------+-------------------------------+-------------------------------+----------
+ pgle_01K8KW44WNEM0B5AKEF3NRAJJ2 | pgla_01K8KW44WHFNZA243705PBPBVH | pglt_01K8KW44WMFGHBYQK301HH4J3F |  50.00 |                     0.00 |                   50.00 |               1 | 2025-10-27 22:20:21.779585+00 | 2025-10-27 22:20:21.779585+00 | 
+ pgle_01K8KW44WNFJ2RF0NPRZ7PQCY0 | pgla_01K8KW44WHFNZA243705PBPBVH | pglt_01K8KW44WNFDAVFY5BEXV08VP1 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-10-27 22:20:21.781562+00 | 2025-10-27 22:20:21.781562+00 | 
 (2 rows)
 
 -- Continuing the example, let's issue a partial refund of the payment. When we
 -- issue the refund, we move the money into the pending_outbound account to
 -- hold it until we get confirmation that it was sent
 SELECT * FROM pgledger_create_transfer(:'user1_available_id',:'user1_pending_outbound_id', 20.00);
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K7WQDC26FBX8NWQ39B1Q2FRH | pgla_01K7WQDC22FFPRD998G0ZYYW01 | pgla_01K7WQDC23E2NSZ5QFWCG0836C |  20.00 | 2025-10-18 22:35:29.222531+00 | 2025-10-18 22:35:29.222531+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------+----------
+ pglt_01K8KW44WPFG0TY4D37ZTV4ZB8 | pgla_01K8KW44WJFRSABYAZK38R44CQ | pgla_01K8KW44WKECJAN13GP605BMYM |  20.00 | 2025-10-27 22:20:21.782565+00 | 2025-10-27 22:20:21.782565+00 | 
 (1 row)
 
 -- Once we get confirmation that that refund was sent, We can move the money
 -- back to the user's external account (e.g. their credit/debit card). Often,
 -- this confirmation will come as a webhook or bank file or similar, so we can
 -- record the event time in the confirmation separately from the time we record
--- the ledger transfer (event_at vs created_at):
+-- the ledger transfer (event_at vs created_at). We can also record extra metadata
+-- as JSON that helps us tie it all together:
 SELECT *
 FROM
     pgledger_create_transfer(
         :'user1_pending_outbound_id',
         :'user1_external_id',
         20.00,
-        event_at => '2025-07-21T12:45:54.123Z'
+        event_at => '2025-07-21T12:45:54.123Z',
+        metadata => '{"webhook_id": "webhook_123"}'
     );
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |          event_at          
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+----------------------------
- pglt_01K7WQDC27EAY9NX3FDY8AYFHP | pgla_01K7WQDC23E2NSZ5QFWCG0836C | pgla_01K7WQDC21E7DA3X5EGARKM63X |  20.00 | 2025-10-18 22:35:29.223033+00 | 2025-07-21 12:45:54.123+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |          event_at          |           metadata            
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+----------------------------+-------------------------------
+ pglt_01K8KW44WQF4CSGA6AGV9C4WT8 | pgla_01K8KW44WKECJAN13GP605BMYM | pgla_01K8KW44WGFBNVZ0WC5WX0A9QT |  20.00 | 2025-10-27 22:20:21.783136+00 | 2025-07-21 12:45:54.123+00 | {"webhook_id": "webhook_123"}
 (1 row)
 
 -- Now, we can query the current state. The external account has -$30 ($50
@@ -105,15 +107,15 @@ WHERE id IN (:'user1_external_id',:'user1_receivables_id',:'user1_available_id',
 -- Next, we can simulate an unexpected case. Let's say we initiate a payment
 -- for $10 but we only receive $8 (e.g. due to unexpected fees):
 SELECT * FROM pgledger_create_transfer(:'user1_external_id',:'user1_receivables_id', 10.00);
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K7WQDC27FF5RP0YXGC7J8MSC | pgla_01K7WQDC21E7DA3X5EGARKM63X | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 |  10.00 | 2025-10-18 22:35:29.223573+00 | 2025-10-18 22:35:29.223573+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------+----------
+ pglt_01K8KW44WREPPVQRMGBAZG2TBA | pgla_01K8KW44WGFBNVZ0WC5WX0A9QT | pgla_01K8KW44WHFNZA243705PBPBVH |  10.00 | 2025-10-27 22:20:21.784193+00 | 2025-10-27 22:20:21.784193+00 | 
 (1 row)
 
 SELECT * FROM pgledger_create_transfer(:'user1_receivables_id',:'user1_available_id', 8.00);
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K7WQDC28EADBK610K6C92P47 | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pgla_01K7WQDC22FFPRD998G0ZYYW01 |   8.00 | 2025-10-18 22:35:29.224044+00 | 2025-10-18 22:35:29.224044+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------+----------
+ pglt_01K8KW44WRFHYA8AEWVXQZ110M | pgla_01K8KW44WHFNZA243705PBPBVH | pgla_01K8KW44WJFRSABYAZK38R44CQ |   8.00 | 2025-10-27 22:20:21.784663+00 | 2025-10-27 22:20:21.784663+00 | 
 (1 row)
 
 -- Now, we can see that our receivables balance is not $0 like we expect:
@@ -128,11 +130,11 @@ WHERE id =:'user1_receivables_id';
 SELECT * FROM pgledger_entries_view
 WHERE account_id =:'user1_receivables_id'
 ORDER BY account_version;
-               id                |           account_id            |           transfer_id           | amount | account_previous_balance | account_current_balance | account_version |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+--------------------------+-------------------------+-----------------+-------------------------------+-------------------------------
- pgle_01K7WQDC25EENVCGSR3S20Z3TF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC24F6X99MCX3FABR6MK |  50.00 |                     0.00 |                   50.00 |               1 | 2025-10-18 22:35:29.219475+00 | 2025-10-18 22:35:29.219475+00
- pgle_01K7WQDC25FPZTRBE6HQFHX0NF | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC25FGRABZFCA8HTC148 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-10-18 22:35:29.221555+00 | 2025-10-18 22:35:29.221555+00
- pgle_01K7WQDC27FQ3TSF3FAQMNFTJW | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC27FF5RP0YXGC7J8MSC |  10.00 |                     0.00 |                   10.00 |               3 | 2025-10-18 22:35:29.223573+00 | 2025-10-18 22:35:29.223573+00
- pgle_01K7WQDC28EHEA1JS1XP47N40M | pgla_01K7WQDC22ERV9HR4D4X4JFQX6 | pglt_01K7WQDC28EADBK610K6C92P47 |  -8.00 |                    10.00 |                    2.00 |               4 | 2025-10-18 22:35:29.224044+00 | 2025-10-18 22:35:29.224044+00
+               id                |           account_id            |           transfer_id           | amount | account_previous_balance | account_current_balance | account_version |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+--------------------------+-------------------------+-----------------+-------------------------------+-------------------------------+----------
+ pgle_01K8KW44WNEM0B5AKEF3NRAJJ2 | pgla_01K8KW44WHFNZA243705PBPBVH | pglt_01K8KW44WMFGHBYQK301HH4J3F |  50.00 |                     0.00 |                   50.00 |               1 | 2025-10-27 22:20:21.779585+00 | 2025-10-27 22:20:21.779585+00 | 
+ pgle_01K8KW44WNFJ2RF0NPRZ7PQCY0 | pgla_01K8KW44WHFNZA243705PBPBVH | pglt_01K8KW44WNFDAVFY5BEXV08VP1 | -50.00 |                    50.00 |                    0.00 |               2 | 2025-10-27 22:20:21.781562+00 | 2025-10-27 22:20:21.781562+00 | 
+ pgle_01K8KW44WREYDVGH82991V3B2E | pgla_01K8KW44WHFNZA243705PBPBVH | pglt_01K8KW44WREPPVQRMGBAZG2TBA |  10.00 |                     0.00 |                   10.00 |               3 | 2025-10-27 22:20:21.784193+00 | 2025-10-27 22:20:21.784193+00 | 
+ pgle_01K8KW44WRFQMVAES6AXTZYB8M | pgla_01K8KW44WHFNZA243705PBPBVH | pglt_01K8KW44WRFHYA8AEWVXQZ110M |  -8.00 |                    10.00 |                    2.00 |               4 | 2025-10-27 22:20:21.784663+00 | 2025-10-27 22:20:21.784663+00 | 
 (4 rows)
 

--- a/examples/multi-currency.sql
+++ b/examples/multi-currency.sql
@@ -52,10 +52,12 @@ SELECT * FROM pgledger_create_transfers(
 -- likely to result in deadlocks since bidrectional transfers will lock the
 -- same accounts in reverse order.
 
--- It is also possible to specify the event_at with `pgledger_create_transfers` using named arguments:
+-- It is also possible to specify the event_at and metadata with
+-- `pgledger_create_transfers` using named arguments:
 SELECT * FROM pgledger_create_transfers(
     event_at => '2025-07-21T12:45:54.123Z',
-    VARIADIC transfer_requests => ARRAY[
+    metadata => '{"external_id": "ext_123"}',
+    transfer_requests => ARRAY[
         (:'user2_usd_id',:'liquidity_usd_id', '10.00'),
         (:'liquidity_eur_id',:'user2_eur_id', '9.26')
     ]::TRANSFER_REQUEST []

--- a/examples/multi-currency.sql.out
+++ b/examples/multi-currency.sql.out
@@ -25,8 +25,8 @@ SELECT * FROM pgledger_accounts_view
 WHERE name LIKE 'user2.%';
                id                |   name    | currency | balance | version | allow_negative_balance | allow_positive_balance |          created_at           |          updated_at           
 ---------------------------------+-----------+----------+---------+---------+------------------------+------------------------+-------------------------------+-------------------------------
- pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.358662+00 | 2025-10-18 22:35:29.358662+00
- pgla_01K7WQDC6GFDCVGQZQZN7CA4AK | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.360634+00 | 2025-10-18 22:35:29.360634+00
+ pgla_01K8KW450GEW5SN6TNP3B06MBT | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-10-27 22:20:21.903242+00 | 2025-10-27 22:20:21.903242+00
+ pgla_01K8KW450HF2ER7TA2ZCXEQCWP | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-10-27 22:20:21.905488+00 | 2025-10-27 22:20:21.905488+00
 (2 rows)
 
 -- And you can even use PostgreSQL's ltree functionality for querying
@@ -37,8 +37,8 @@ SELECT * FROM pgledger_accounts_view
 WHERE name::LTREE <@ 'user2';
                id                |   name    | currency | balance | version | allow_negative_balance | allow_positive_balance |          created_at           |          updated_at           
 ---------------------------------+-----------+----------+---------+---------+------------------------+------------------------+-------------------------------+-------------------------------
- pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.358662+00 | 2025-10-18 22:35:29.358662+00
- pgla_01K7WQDC6GFDCVGQZQZN7CA4AK | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-10-18 22:35:29.360634+00 | 2025-10-18 22:35:29.360634+00
+ pgla_01K8KW450GEW5SN6TNP3B06MBT | user2.usd | USD      |       0 |       0 | t                      | t                      | 2025-10-27 22:20:21.903242+00 | 2025-10-27 22:20:21.903242+00
+ pgla_01K8KW450HF2ER7TA2ZCXEQCWP | user2.eur | EUR      |       0 |       0 | t                      | t                      | 2025-10-27 22:20:21.905488+00 | 2025-10-27 22:20:21.905488+00
 (2 rows)
 
 -- Now, we can see that pgledger prevents transfers between accounts of different currencies:
@@ -46,12 +46,13 @@ SELECT * FROM pgledger_create_transfer(:'user2_usd_id',:'user2_eur_id', 10.00);
 -- Instead, we need to create liquidity accounts per currency and use those for the transfers:
 SELECT id FROM pgledger_create_account('liquidity.usd', 'USD') \gset liquidity_usd_
 ERROR:  Cannot transfer between different currencies (USD and EUR)
-CONTEXT:  PL/pgSQL function pgledger_create_transfers(timestamp with time zone,transfer_request[]) line 64 at RAISE
+CONTEXT:  PL/pgSQL function pgledger_create_transfers(transfer_request[],timestamp with time zone,jsonb) line 64 at RAISE
 SQL statement "SELECT * FROM pgledger_create_transfers(
-        event_at,
-        ROW(from_account_id, to_account_id, amount)::transfer_request
+        transfer_requests => array[(from_account_id, to_account_id, amount)::TRANSFER_REQUEST],
+        event_at => event_at,
+        metadata => metadata
     )"
-PL/pgSQL function pgledger_create_transfer(text,text,numeric,timestamp with time zone) line 4 at RETURN QUERY
+PL/pgSQL function pgledger_create_transfer(text,text,numeric,timestamp with time zone,jsonb) line 4 at RETURN QUERY
 SELECT id FROM pgledger_create_account('liquidity.eur', 'EUR') \gset liquidity_eur_
 -- Now, a currency conversion consist of 2 transfers using the 4 accounts. The
 -- difference between these two different amounts (10.00 vs 9.26) is the
@@ -60,10 +61,10 @@ SELECT * FROM pgledger_create_transfers(
     (:'user2_usd_id',:'liquidity_usd_id', '10.00'),
     (:'liquidity_eur_id',:'user2_eur_id', '9.26')
 );
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------
- pglt_01K7WQDC6VE9ARJ9ZGX4TAGXZQ | pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | pgla_01K7WQDC6TED9VZP8CQWZV00AJ |  10.00 | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00
- pglt_01K7WQDC6VF2QRVCX16VSN4ZSC | pgla_01K7WQDC6TF7VSY5PWXJ95B28H | pgla_01K7WQDC6GFDCVGQZQZN7CA4AK |   9.26 | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |           event_at            | metadata 
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+-------------------------------+----------
+ pglt_01K8KW450TEMQR5D1PMN84E3XD | pgla_01K8KW450GEW5SN6TNP3B06MBT | pgla_01K8KW450SEPRRK9M9K05239GS |  10.00 | 2025-10-27 22:20:21.914072+00 | 2025-10-27 22:20:21.914072+00 | 
+ pglt_01K8KW450TFFQVC802F9EWNDW6 | pgla_01K8KW450SFKCVV9A88247H03Q | pgla_01K8KW450HF2ER7TA2ZCXEQCWP |   9.26 | 2025-10-27 22:20:21.914072+00 | 2025-10-27 22:20:21.914072+00 | 
 (2 rows)
 
 -- Note that this used the plural `pgledger_create_transfers` instead of the
@@ -71,18 +72,20 @@ SELECT * FROM pgledger_create_transfers(
 -- `pgledger_create_transfer` twice in a database transaction, but that is more
 -- likely to result in deadlocks since bidrectional transfers will lock the
 -- same accounts in reverse order.
--- It is also possible to specify the event_at with `pgledger_create_transfers` using named arguments:
+-- It is also possible to specify the event_at and metadata with
+-- `pgledger_create_transfers` using named arguments:
 SELECT * FROM pgledger_create_transfers(
     event_at => '2025-07-21T12:45:54.123Z',
-    VARIADIC transfer_requests => ARRAY[
+    metadata => '{"external_id": "ext_123"}',
+    transfer_requests => ARRAY[
         (:'user2_usd_id',:'liquidity_usd_id', '10.00'),
         (:'liquidity_eur_id',:'user2_eur_id', '9.26')
     ]::TRANSFER_REQUEST []
 );
-               id                |         from_account_id         |          to_account_id          | amount |          created_at           |          event_at          
----------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+----------------------------
- pglt_01K7WQDC6WE1WTT4B8P2WQDXYG | pgla_01K7WQDC6FF9VVPW9AZVCHXDHY | pgla_01K7WQDC6TED9VZP8CQWZV00AJ |  10.00 | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00
- pglt_01K7WQDC6WEEMBCWSF0G00PJKA | pgla_01K7WQDC6TF7VSY5PWXJ95B28H | pgla_01K7WQDC6GFDCVGQZQZN7CA4AK |   9.26 | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00
+               id                |         from_account_id         |          to_account_id          | amount |          created_at           |          event_at          |          metadata          
+---------------------------------+---------------------------------+---------------------------------+--------+-------------------------------+----------------------------+----------------------------
+ pglt_01K8KW450VEWRRCK9FXHEBVNM6 | pgla_01K8KW450GEW5SN6TNP3B06MBT | pgla_01K8KW450SEPRRK9M9K05239GS |  10.00 | 2025-10-27 22:20:21.915314+00 | 2025-07-21 12:45:54.123+00 | {"external_id": "ext_123"}
+ pglt_01K8KW450VF8HS49G8ADDG5KJH | pgla_01K8KW450SFKCVV9A88247H03Q | pgla_01K8KW450HF2ER7TA2ZCXEQCWP |   9.26 | 2025-10-27 22:20:21.915314+00 | 2025-07-21 12:45:54.123+00 | {"external_id": "ext_123"}
 (2 rows)
 
 -- Here is what the transfers look like holistically:
@@ -99,9 +102,9 @@ LEFT JOIN pgledger_accounts_view acc_to ON t.to_account_id = acc_to.id
 WHERE acc_from.name LIKE 'user2.%' OR acc_from.name LIKE 'liquidity.%';
                id                |          created_at           |           event_at            |   acc_from    |    acc_to     | amount 
 ---------------------------------+-------------------------------+-------------------------------+---------------+---------------+--------
- pglt_01K7WQDC6VE9ARJ9ZGX4TAGXZQ | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00 | user2.usd     | liquidity.usd |  10.00
- pglt_01K7WQDC6VF2QRVCX16VSN4ZSC | 2025-10-18 22:35:29.370906+00 | 2025-10-18 22:35:29.370906+00 | liquidity.eur | user2.eur     |   9.26
- pglt_01K7WQDC6WE1WTT4B8P2WQDXYG | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00    | user2.usd     | liquidity.usd |  10.00
- pglt_01K7WQDC6WEEMBCWSF0G00PJKA | 2025-10-18 22:35:29.371887+00 | 2025-07-21 12:45:54.123+00    | liquidity.eur | user2.eur     |   9.26
+ pglt_01K8KW450TEMQR5D1PMN84E3XD | 2025-10-27 22:20:21.914072+00 | 2025-10-27 22:20:21.914072+00 | user2.usd     | liquidity.usd |  10.00
+ pglt_01K8KW450TFFQVC802F9EWNDW6 | 2025-10-27 22:20:21.914072+00 | 2025-10-27 22:20:21.914072+00 | liquidity.eur | user2.eur     |   9.26
+ pglt_01K8KW450VEWRRCK9FXHEBVNM6 | 2025-10-27 22:20:21.915314+00 | 2025-07-21 12:45:54.123+00    | user2.usd     | liquidity.usd |  10.00
+ pglt_01K8KW450VF8HS49G8ADDG5KJH | 2025-10-27 22:20:21.915314+00 | 2025-07-21 12:45:54.123+00    | liquidity.eur | user2.eur     |   9.26
 (4 rows)
 

--- a/go/test/test_helpers.go
+++ b/go/test/test_helpers.go
@@ -37,6 +37,7 @@ type Transfer struct {
 	Amount        string
 	CreatedAt     time.Time
 	EventAt       time.Time
+	Metadata      *string
 }
 
 type Entry struct {
@@ -49,6 +50,7 @@ type Entry struct {
 	AccountVersion         int
 	CreatedAt              time.Time
 	EventAt                time.Time
+	Metadata               *string
 }
 
 func setupTest(t *testing.T) *pgxpool.Pool {


### PR DESCRIPTION
Update `pgledger_create_transfer` and `pgledger_create_transfers` to take an optional JSON `metadata` argument, which is recorded alongside the transfer.

Also update the example scripts to show how to pass and use the new metadata.

For simplicity, the `transfer_requests` argument is no longer variadic in the function version which takes all arguments. This allows us to pass in the arguments in any order with the same syntax.