### PR TITLE
Always require tests to run before merging

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,6 +56,7 @@ jobs:
     needs: test
     runs-on: ubuntu-24.04
     steps:
+      # This approach is from: https://github.com/orgs/community/discussions/28864
       - name: Fail unless required checks pass
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1


### PR DESCRIPTION
This is an attempt to fix an issue where a test fails, so the
all-tests-passed is skipped but considered successful. And then GitHub
will do an auto-merge even though the test is failing.
