### PR TITLE
Use mise to install dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,11 +22,9 @@ jobs:
 
       - uses: extractions/setup-just@v3
 
-      # For uvx sqlfluff
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - uses: jdx/mise-action@v3
         with:
-          enable-cache: true
+          log_level: info
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -43,13 +41,6 @@ jobs:
         run: just --timestamp check
         env:
           POSTGRES_VERSION: ${{ matrix.postgres_version }}
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          working-directory: go
-          version: latest
-          args: --timeout 2m --verbose
 
   all-tests-passed:
     if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Bytes/transfer: 743
 ## Development
 
 While the implementation of `pgledger` is all SQL, I do use various tools to help with the development:
+- [Mise](https://mise.jdx.dev/) for managing tools and dependencies
 - [Go](https://go.dev/) for writing tests
 - [just](https://github.com/casey/just) for running tasks (e.g. `just check` to run the full suite of tests and linters)
 - [uv](https://docs.astral.sh/uv/) for running [sqlfluff](https://github.com/sqlfluff/sqlfluff), the SQL formatter/linter written in Python
@@ -192,7 +193,9 @@ While the implementation of `pgledger` is all SQL, I do use various tools to hel
 If you're on MacOS, these tools can all be installed via [Homebrew](https://brew.sh/):
 
 ```bash
-brew install go just uv docker-desktop
+brew install mise docker-desktop
+
+mise install
 ```
 
 Then you can run PostgreSQL in a docker container:

--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -1,0 +1,8 @@
+version: "2"
+linters:
+  enable:
+    - modernize
+formatters:
+  enable:
+    - gofmt
+    - gofumpt

--- a/justfile
+++ b/justfile
@@ -1,7 +1,5 @@
 dbname := "pgledger"
 
-MODERNIZE_CMD := "golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest"
-
 psql:
   docker compose exec postgres env PGPASSWORD={{dbname}} psql -U {{dbname}} {{dbname}}
 
@@ -35,7 +33,7 @@ benchmark:
 performance_check duration='10s':
   cd go && go run performance_check.go --duration {{duration}}
 
-lint: deadcode modernize lint-sql
+lint: deadcode lint-sql golangci-lint
 
 deadcode:
   #!/usr/bin/env bash
@@ -51,8 +49,8 @@ deadcode:
       echo "No dead code"
   fi
 
-modernize:
-  cd go && go run {{MODERNIZE_CMD}} -test ./...
+golangci-lint:
+  cd go && golangci-lint run --verbose
 
 lint-sql:
   uvx sqlfluff@3.5.0 lint --verbose

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+go = "1.25.3"           # Matches the version in go.mod
+uv = "0.9.5"
+just = "1.43.0"
+golangci-lint = "2.6.0"


### PR DESCRIPTION
This lets us more easily run golangci-lint as part of `just lint`,
including controlling the version. And the new version of golangci-lint
includes `modernize`, so we can remove our custom code for it.
