### PR TITLE
Test against latest minor PostgreSQL version for each major version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        postgres_version: ["15.14", "16.10", "17.6", "18.0"]
+        postgres_version: ["15", "16", "17", "18"]
 
     steps:
       - uses: actions/checkout@v5
@@ -33,9 +33,12 @@ jobs:
           cache-dependency-path: "go/go.sum"
 
       - name: Start Docker Compose
-        run: docker compose up --wait
+        run: docker compose up --pull always --wait
         env:
           POSTGRES_VERSION: ${{ matrix.postgres_version }}
+
+      - name: Print PostgreSQL version
+        run: just --timestamp dbversion
 
       - name: Run tests and linters
         run: just --timestamp check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: "pgledger_postgres"
-    image: "postgres:${POSTGRES_VERSION:-18.0}"
+    image: "postgres:${POSTGRES_VERSION:-18}"
     command: >
       -c max_wal_size=2GB
     ports:

--- a/go/test/matrix_test.go
+++ b/go/test/matrix_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -11,17 +12,17 @@ import (
 func TestMatrixPostgresVersion(t *testing.T) {
 	expectedVersion := os.Getenv("POSTGRES_VERSION")
 	if expectedVersion == "" {
-		expectedVersion = "18.0"
+		expectedVersion = "18"
 	}
-	assert.Regexp(t, `\d+\.\d+`, expectedVersion)
+	assert.Regexp(t, `^\d+$`, expectedVersion)
 
 	conn := dbconn(t)
 
-	rows, err := conn.Query(t.Context(), "select * from version()")
+	rows, err := conn.Query(t.Context(), "select version()")
 	assert.NoError(t, err)
 
 	version, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[string])
 	assert.NoError(t, err)
 
-	assert.Contains(t, version, expectedVersion)
+	assert.Contains(t, version, fmt.Sprintf("PostgreSQL %s.", expectedVersion))
 }

--- a/justfile
+++ b/justfile
@@ -3,6 +3,9 @@ dbname := "pgledger"
 psql:
   docker compose exec postgres env PGPASSWORD={{dbname}} psql -U {{dbname}} {{dbname}}
 
+dbversion:
+  docker compose exec postgres env PGPASSWORD={{dbname}} psql -U {{dbname}} {{dbname}} -c 'select version();'
+
 dbclean:
   docker compose exec postgres dropdb --force -U {{dbname}} {{dbname}} || echo "db doesn't exist"
   docker compose exec postgres createdb -U {{dbname}} {{dbname}}


### PR DESCRIPTION
- Only specify major PostgreSQL version in docker compose, not minor version
- Always pull the latest docker image for that major version
- Print the current version as a step for info/debugging
- Update matrix_test.go to assert against major version
