### PR TITLE
Switch sqlfluff to a mise tool

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,10 +56,10 @@ golangci-lint:
     cd go && golangci-lint run --verbose
 
 lint-sql:
-    uvx sqlfluff@4.0.0 lint --verbose
+    sqlfluff lint --verbose
 
 format-sql:
-    uvx sqlfluff@4.0.0 format
+    sqlfluff format
 
 check: dbreset clean tidy format-sql test lint
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
-go = "1.26.1"           # Matches the version in go.mod
+go = "1.26.1"             # Matches the version in go.mod
 uv = "0.11.2"
 just = "1.48.1"
 golangci-lint = "2.11.4"
+"pipx:sqlfluff" = "4.0.0"


### PR DESCRIPTION
This installs sqlfluff like the other mise tools instead of using uvx directly. It should also allow renovate to suggest upgrades like it does with the rest of our tools.

The pipx backend actually uses `uvx` when `uv` is installed: https://mise.jdx.dev/dev-tools/backends/pipx.html