### PR TITLE
Switch just in mise to use github backend

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-go = "1.26.2"             # Matches the version in go.mod
+go = "1.26.2"                  # Matches the version in go.mod
 uv = "0.11.2"
-just = "1.50.0"
+"github:casey/just" = "1.50.0"
 golangci-lint = "2.11.4"
 "pipx:sqlfluff" = "4.0.0"


### PR DESCRIPTION
The default `just` tool is now causing an installation error:

    mise WARN  deprecated [ubi]: The ubi backend is deprecated. Use the
    github backend instead (e.g., github:owner/repo). This will be
    removed in mise 2027.1.0.