### PR TITLE
Allow running PostgreSQL on a custom port via POSTGRES_PORT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/settings.local.json
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ docker compose up      # start PostgreSQL
 just check             # full suite: dbreset, clean, tidy, format-sql, test, lint
 ```
 
+`POSTGRES_PORT` (default 5432) sets the host port Docker Compose publishes and the port the Go tests and `performance_check` connect to. The justfile has `set dotenv-load := true`, so a `.env` file with `POSTGRES_PORT=5433` gives a checkout its own database container; real environment variables take precedence over `.env`.
+
 Common commands:
 
 | Command | What it does |
@@ -90,7 +92,7 @@ Common commands:
 
 ## Testing
 
-Tests are Go integration tests in `go/test/` using pgx and testify. They connect to PostgreSQL at `postgres://pgledger:pgledger@localhost:5432/pgledger`. All tests call the SQL functions directly and verify results through the views.
+Tests are Go integration tests in `go/test/` using pgx and testify. They connect to PostgreSQL at `postgres://pgledger:pgledger@localhost:5432/pgledger`, where the port comes from `POSTGRES_PORT` (default 5432) via `go/internal/dburl`. All tests call the SQL functions directly and verify results through the views.
 
 Test helpers in `go/test/test_helpers.go` define Go structs (Account, Transfer, Entry) that map to the view columns, plus helper functions for creating accounts, transfers, and querying entries.
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ Then you can run PostgreSQL in a docker container:
 docker compose up
 ```
 
+PostgreSQL listens on port 5432 by default. To run multiple checkouts (e.g.
+separate [git worktrees](https://git-scm.com/docs/git-worktree) or
+[jj workspaces](https://docs.jj-vcs.dev/latest/working-copy/#workspaces)) against their own databases, set
+`POSTGRES_PORT` in a `.env` file in the checkout, which both Docker Compose and
+the tests pick up:
+
+```bash
+echo POSTGRES_PORT=5433 > .env
+```
+
 And run the full set of tests and linters with:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
 services:
   postgres:
-    container_name: "pgledger_postgres"
     image: "postgres:${POSTGRES_VERSION:-18}"
     command: >
       -c max_wal_size=2GB
     ports:
-      - 5432:5432
+      - ${POSTGRES_PORT:-5432}:5432
     networks:
       - postgres-network
     environment:

--- a/go/internal/dburl/dburl.go
+++ b/go/internal/dburl/dburl.go
@@ -1,0 +1,15 @@
+package dburl
+
+import (
+	"fmt"
+	"os"
+)
+
+func URL() string {
+	port := os.Getenv("POSTGRES_PORT")
+	if port == "" {
+		port = "5432"
+	}
+
+	return fmt.Sprintf("postgres://pgledger:pgledger@localhost:%s/pgledger", port)
+}

--- a/go/performance_check.go
+++ b/go/performance_check.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgr0ss/pgledger/internal/dburl"
 )
 
 var (
@@ -47,7 +48,7 @@ func main() {
 	numAccounts, numWorkers, runDuration, vacuum := parseArgs()
 
 	ctx := context.Background()
-	dbconn := Must1(pgxpool.New(ctx, "postgres://pgledger:pgledger@localhost:5432/pgledger"))
+	dbconn := Must1(pgxpool.New(ctx, dburl.URL()))
 	defer dbconn.Close()
 
 	fmt.Printf("Creating %d accounts\n", numAccounts)

--- a/go/test/test_helpers.go
+++ b/go/test/test_helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pgr0ss/pgledger/internal/dburl"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +61,7 @@ func setupTest(t *testing.T) *pgxpool.Pool {
 }
 
 func dbconn(t TestingT) *pgxpool.Pool {
-	dbpool, err := pgxpool.New(context.Background(), "postgres://pgledger:pgledger@localhost:5432/pgledger")
+	dbpool, err := pgxpool.New(context.Background(), dburl.URL())
 	assert.NoError(t, err)
 
 	t.Cleanup(dbpool.Close)

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set dotenv-load := true
+
 dbname := "pgledger"
 
 psql:


### PR DESCRIPTION
This is to support running multiple git worktrees or jj workspaces concurrently on different PostgreSQL ports.